### PR TITLE
Use a local Sqlite database instead of a SQL Server on non-production environments

### DIFF
--- a/Source/WebApi-Data-Provider-DotNet/WebApi-Data-Provider-DotNet.csproj
+++ b/Source/WebApi-Data-Provider-DotNet/WebApi-Data-Provider-DotNet.csproj
@@ -18,6 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.17" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.17" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.17">
 			<PrivateAssets>All</PrivateAssets>
 		</PackageReference>

--- a/Source/WebApi-Data-Provider-DotNet/appsettings.Development.json
+++ b/Source/WebApi-Data-Provider-DotNet/appsettings.Development.json
@@ -1,5 +1,6 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-WebApi_Data_Provider_DotNet;Trusted_Connection=True;MultipleActiveResultSets=true;"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-WebApi_Data_Provider_DotNet;Trusted_Connection=True;MultipleActiveResultSets=true;",
+    "SqliteConnection": "DataSource=app.db"
   }
 }


### PR DESCRIPTION
As a sqlite database is saved in the filesystem, this lowers the cost of development/demo environments.