### PR TITLE
Replace Sqlite with an InMemoryDatabase for non production environments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -53,8 +53,8 @@ jobs:
         publish-profile: ${{ env.AZURE_WEBAPP_PUBLISH_PROFILE }}
         
     - name: Apply database migrations
-      if: ${{ steps.deploy.conclusion == 'success' }}
-      run: dotnet ef database update
+      if: ${{ steps.deploy.conclusion == 'success' && env.CONFIGURATION == 'Production' }}
+      run: dotnet ef database update --project "${{ env.WORKING_DIRECTORY }}"
       working-directory: ${{ env.WORKING_DIRECTORY }}
       env:
         ASPNETCORE_ENVIRONMENT: ${{ env.CONFIGURATION }}

--- a/Source/WebApi-Data-Provider-DotNet/Startup.cs
+++ b/Source/WebApi-Data-Provider-DotNet/Startup.cs
@@ -62,8 +62,8 @@ namespace WebApi_Data_Provider_DotNet
                 }
                 else
                 {
-                    //Sqlite is suggested for development environments, as the database is thus hosted on the filesystem instead of a server.
-                    options.UseSqlite(Configuration.GetConnectionString("SqliteConnection"));
+                    // Suggested for development environments, as the database is thus hosted with the web app instead of a separate server.
+                    options.UseInMemoryDatabase("InMemory");
                 }
             });
 
@@ -85,10 +85,6 @@ namespace WebApi_Data_Provider_DotNet
                 app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
                 app.UseDatabaseErrorPage();
-
-                // Apply any pending database migrations on startup (includes initial db creation)
-                dbContext.Database.Migrate();
-                // This is not recommended for production databases. See https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/applying#apply-migrations-at-runtime
             }
             app.UseStaticFiles();
 

--- a/Source/WebApi-Data-Provider-DotNet/WebApi-Data-Provider-DotNet.csproj
+++ b/Source/WebApi-Data-Provider-DotNet/WebApi-Data-Provider-DotNet.csproj
@@ -18,7 +18,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.17" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.17" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.17" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.17">
 			<PrivateAssets>All</PrivateAssets>
 		</PackageReference>

--- a/Source/WebApi-Data-Provider-DotNet/appsettings.Development.json
+++ b/Source/WebApi-Data-Provider-DotNet/appsettings.Development.json
@@ -1,6 +1,5 @@
 ﻿{
   "ConnectionStrings": {
-    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-WebApi_Data_Provider_DotNet;Trusted_Connection=True;MultipleActiveResultSets=true;",
-    "SqliteConnection": "DataSource=app.db"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=aspnetcore-WebApi_Data_Provider_DotNet;Trusted_Connection=True;MultipleActiveResultSets=true;"
   }
 }


### PR DESCRIPTION
Because Azure linux environments seems to have an ongoing issue with sqlite database. [Relevant stackoverflow](https://stackoverflow.com/questions/53226642/sqlite3-database-is-locked-in-azure)