### PR TITLE
Migrate to .NET 5

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -16,7 +16,8 @@ env:
   WORKING_DIRECTORY: Source/WebApi-Data-Provider-DotNet/
   CONFIGURATION: Debug
   ASPNETCORE_ENVIRONMENT: Development
-  DOTNET_CORE_VERSION: 3.1.x
+  CONFIGURATION: Development
+  DOTNET_CORE_VERSION: 5.0.x
 
 jobs:
   build-and-deploy:

--- a/Source/FranceConnect.DataProvider/FranceConnect.DataProvider.csproj
+++ b/Source/FranceConnect.DataProvider/FranceConnect.DataProvider.csproj
@@ -4,7 +4,7 @@
     <Description>Middleware and filter for FranceConnect data providers</Description>
     <Copyright>Microsoft France</Copyright>
     <Authors>Microsoft France</Authors>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>FranceConnect.DataProvider</AssemblyName>
     <PackageId>FranceConnect.DataProvider</PackageId>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/Source/WebApi-Data-Provider-DotNet/Startup.cs
+++ b/Source/WebApi-Data-Provider-DotNet/Startup.cs
@@ -44,6 +44,7 @@ namespace WebApi_Data_Provider_DotNet
                     options.UseInMemoryDatabase("InMemory");
                 }
             });
+            services.AddDatabaseDeveloperPageExceptionFilter();
 
             // Add framework services.
             services.AddControllersWithViews();
@@ -62,7 +63,7 @@ namespace WebApi_Data_Provider_DotNet
             {
                 app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
-                app.UseDatabaseErrorPage();
+                app.UseMigrationsEndPoint();
             }
             app.UseStaticFiles();
 

--- a/Source/WebApi-Data-Provider-DotNet/WebApi-Data-Provider-DotNet.csproj
+++ b/Source/WebApi-Data-Provider-DotNet/WebApi-Data-Provider-DotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFramework>net5.0</TargetFramework>
 		<AssemblyName>WebApi-Data-Provider</AssemblyName>
 		<PackageId>WebApi-Data-Provider</PackageId>
 	</PropertyGroup>
@@ -17,13 +17,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.17" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.17" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.17">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.8">
 			<PrivateAssets>All</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="3.1.17" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.17" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
Migrate project & dependencies to .NET 5, and migrate newly deprecated methods.

Github Actions now use .NET 5 as well.
**Note : The Azure App Service used for deployment must be updated to use .NET 5 before merging.**